### PR TITLE
[MULTI DIMENSIONAL ARRAYS] 

### DIFF
--- a/PropertyAccessor.php
+++ b/PropertyAccessor.php
@@ -88,7 +88,7 @@ class PropertyAccessor implements PropertyAccessorInterface
                 $this->writeProperty($objectOrArray, $property, $value);
             }
 
-            if ($propertyValues[$i][self::IS_REF]) {
+            if ($propertyValues[$i][self::IS_REF] && is_object($objectOrArray)) {
                 return;
             }
 
@@ -149,7 +149,7 @@ class PropertyAccessor implements PropertyAccessorInterface
                     }
                 }
 
-                if ($propertyValues[$i][self::IS_REF]) {
+                if ($propertyValues[$i][self::IS_REF] && is_object($objectOrArray)) {
                     return true;
                 }
             }


### PR DESCRIPTION
setValue & isWratable loops must only stops on reference and object. References can also be arrays in object properties and stopping the loop breaks since 2.6.5  commit e3e46956b0267d422a507b2e68abd57f51671b2a

This merge request fixes the following cases:

a class with a property myArray which can be a multi dimensional array can now be accesed using myArray[foo][bar][baz]
Previously only myArray[foo] was working